### PR TITLE
Multiple bugfixes and improvements

### DIFF
--- a/configs/MixSettings.ini
+++ b/configs/MixSettings.ini
@@ -43,6 +43,14 @@ PAUSE_DURATION = 60
 # 0 - No | 1 - Yes
 START_TEN_REQUIRED = 1
 
+# Knife round finish delay.
+# Also the time players have to vote the start side.
+# Time must be in seconds.
+KNIFE_ROUND_START_DELAY = 10
+
+# Start points for new players.
+DEFAULT_START_POINTS = 700
+
 [Commands Section]
 
 # Note:

--- a/data/lang/mix_system.txt
+++ b/data/lang/mix_system.txt
@@ -18,6 +18,7 @@ KNIFE_STARTED = ^1The Knife Round has started.
 KNIFE_STARTED_BY_YOU = ^1The Knife Round was started by ^4You^1.
 KNIFE_STARTED_BY_X = ^1The Knife Round was started by ^4%s^1.
 KNIFE_ROUND_WON_BY_X_TEAM = ^1The Knife Round was won by team ^4%s^1.
+KNIFE_ROUND_MATCH_START_IN = ^1The Match will start in ^4%d ^1seconds.
 
 CT_TEAM = CT
 TERO_TEAM = TERRORIST
@@ -141,6 +142,11 @@ RECEIVED = received
 
 MIX_NEED_STOP_TO_CHANGEMAP = Mix needs to be ^3stopped^1 to change the map.
 
+MATCHSTATE_WARM = [Warmup]
+MATCHSTATE_IN_MATCH = [CT %d - TERO %d]
+MATCHSTATE_KNIFE_ROUND = [Knife Round]
+MATCHSTATE_OVERTIME = Overtime [CT %d - TERO %d]
+
 [ro]
 YOU_DONT_HAVE_ACCESS = ^1Nu ai acces la aceasta comanda!
 
@@ -161,6 +167,7 @@ KNIFE_STARTED = ^1Runda de cutite a pornit.
 KNIFE_STARTED_BY_YOU = ^1Runda de Cutite a fost pornita de catre ^4Tine^1.
 KNIFE_STARTED_BY_X = ^1Runda de Cutite a fost pornita de catre ^4%s^1.
 KNIFE_ROUND_WON_BY_X_TEAM = ^1Runda de Cutite a fost castigata de echipa ^4%s^1.
+KNIFE_ROUND_MATCH_START_IN = ^1Meciul va incepe in ^4%d ^1secunde.
 
 CT_TEAM = CT
 TERO_TEAM = TERRORIST
@@ -284,6 +291,11 @@ RECEIVED = primit
 
 MIX_NEED_STOP_TO_CHANGEMAP = Mix-ul trebuie sa fie ^3oprit^1 pentru a putea schimba harta.
 
+MATCHSTATE_WARM = [Incalzire]
+MATCHSTATE_IN_MATCH = [CT %d - TERO %d]
+MATCHSTATE_KNIFE_ROUND = [Runda de cutite]
+MATCHSTATE_OVERTIME = Overtime [CT %d - TERO %d]
+
 [ru]
 YOU_DONT_HAVE_ACCESS = ^1Вы не имеете доступа к этой команде!
 
@@ -304,6 +316,7 @@ KNIFE_STARTED = ^1Ножевой раунд начался.
 KNIFE_STARTED_BY_YOU = ^1Ножевой раунд был начат ^4вами^1.
 KNIFE_STARTED_BY_X = ^1Ножевой раунд был начат игроком ^4%s^1.
 KNIFE_ROUND_WON_BY_X_TEAM = ^1Ножевой раунд выиграла команда ^4%s^1.
+KNIFE_ROUND_MATCH_START_IN = ^1Матч начнется через ^4%d ^1секунд.
 
 CT_TEAM = КТ
 TERO_TEAM = ТЕРРОРИСТЫ
@@ -426,3 +439,8 @@ DAMAGE = урон
 RECEIVED = принятый
 
 MIX_NEED_STOP_TO_CHANGEMAP = Чтобы иметь возможность сменить карту, игра должна быть ^3остановлена^1.
+
+MATCHSTATE_WARM = [Разминка]
+MATCHSTATE_IN_MATCH = [CT %d - TERO %d]
+MATCHSTATE_KNIFE_ROUND = [Раунд с ножом]
+MATCHSTATE_OVERTIME = Дополнительное время [CT %d - TERO %d]

--- a/scripting/mix_database_stats.sma
+++ b/scripting/mix_database_stats.sma
@@ -102,11 +102,11 @@ public mix_database_connected(Handle:hTuple, Handle:iSqlConn)
 
 	if(g_iSqlConnection == Empty_Handle)
 	{
-		log_to_file("mix_system.log", "{%s} Failed to connect to database. Make sure databse settings are right!", PLUGIN)
+		log_to_file("mix_system_stats.log", "{%s} Failed to connect to database. Make sure databse settings are right!", PLUGIN)
 		return
 	}
 
-	new szQueryData[612];
+	new szQueryData[800];
 	formatex(szQueryData, charsmax(szQueryData), "CREATE TABLE IF NOT EXISTS `%s` \
 	(`MatchID` int(11) NOT NULL,\
 	  `SteamID` varchar(32) NOT NULL,\
@@ -122,6 +122,7 @@ public mix_database_connected(Handle:hTuple, Handle:iSqlConn)
 	  `PointsEnd` int(11) NOT NULL DEFAULT 0,\
 	  `MVPS` int(11) NOT NULL DEFAULT 0,\
 	  `Winner` int(1) NOT NULL DEFAULT 0,\
+	  `updated_at` timestamp NOT NULL DEFAULT current_timestamp() ON UPDATE current_timestamp(), \
 		PRIMARY KEY(MatchID, SteamID));", PLAYERS_TABLE)
 
 	SQL_ThreadQuery(g_hSqlTuple, "QueryHandler", szQueryData)
@@ -134,10 +135,11 @@ public mix_database_connected(Handle:hTuple, Handle:iSqlConn)
 	  `Winner` varchar(12) DEFAULT 'In Progress',\
 	  `CTScore` int(11) NOT NULL,\
 	  `TSCORE` int(11) NOT NULL,\
-	  `Timestamp` datetime NOT NULL DEFAULT current_timestamp() ON UPDATE current_timestamp(),\
+	  `Timestamp` timestamp NOT NULL DEFAULT current_timestamp() ON UPDATE current_timestamp(),\
 	  `CT` VARCHAR(32) NOT NULL DEFAULT 'CT',\
 	  `TE` VARCHAR(32) NOT NULL DEFAULT 'T',\
 	  `Status` VARCHAR(32) NOT NULL DEFAULT 'In Progress',\
+	  `updated_at` timestamp NOT NULL DEFAULT current_timestamp() ON UPDATE current_timestamp(), \
 		PRIMARY KEY(MatchID));", MATCH_TABLE)
 
 	SQL_ThreadQuery(g_hSqlTuple, "QueryHandler", szQueryData)
@@ -155,8 +157,8 @@ public mix_database_connected(Handle:hTuple, Handle:iSqlConn)
 
 		if(containi(g_szSqlError, "Unknown column") != -1)
 		{
-			formatex(szQueryData, charsmax(szQueryData), "ALTER TABLE `%s` ADD `JoinDate` DATE NOT NULL DEFAULT current_timestamp(), \
-			    ADD `LastSeenDate` DATETIME NOT NULL DEFAULT current_timestamp() ON UPDATE current_timestamp()", szTemp)
+			formatex(szQueryData, charsmax(szQueryData), "ALTER TABLE `%s` ADD `JoinDate` DATE, \
+			    ADD `LastSeenDate` timestamp NOT NULL DEFAULT current_timestamp() ON UPDATE current_timestamp()", szTemp)
 
 			SQL_ThreadQuery(g_hSqlTuple, "QueryHandler", szQueryData)
 		}
@@ -260,6 +262,8 @@ public mix_match_winner(iPlayer)
 	SQL_ThreadQuery(g_hSqlTuple, "QueryHandler", szQuery, szQuery, sizeof(szQuery))
 
 	g_ePlayerData[iPlayer][iWins] += 1
+
+	mix_user_save(iPlayer)
 }
 
 SetDropped(id)
@@ -460,12 +464,12 @@ public QueryHandlerLoad(iFailState, Handle:iQuery, szError[], iErrorCode, sTemp[
 	{
 		case TQUERY_CONNECT_FAILED: 
 		{
-			log_to_file("mix_system.log", "[SQL Error] Connection failed (%i): %s", iErrorCode, szError);
+			log_to_file("mix_system_stats.log", "[SQL Error] Connection failed (%i): %s", iErrorCode, szError);
 			return 
 		}
 		case TQUERY_QUERY_FAILED:
 		{
-			log_to_file("mix_system.log", "[SQL Error] Query failed (%i): %s", iErrorCode, szError);
+			log_to_file("mix_system_stats.log", "[SQL Error] Query failed (%i): %s", iErrorCode, szError);
 			return
 		}
 	}
@@ -517,12 +521,12 @@ public HandleLoad(iFailState, Handle:iQuery, szError[], iErrorCode, sTemp[])
 	{
 		case TQUERY_CONNECT_FAILED: 
 		{
-			log_to_file("mix_system.log", "[SQL Error] Connection failed (%i): %s", iErrorCode, szError);
+			log_to_file("mix_system_stats.log", "[SQL Error] Connection failed (%i): %s", iErrorCode, szError);
 			return 
 		}
 		case TQUERY_QUERY_FAILED:
 		{
-			log_to_file("mix_system.log", "[SQL Error] Query failed (%i): %s", iErrorCode, szError);
+			log_to_file("mix_system_stats.log", "[SQL Error] Query failed (%i): %s", iErrorCode, szError);
 			return 
 		}
 	}
@@ -549,10 +553,10 @@ public QueryHandler(iFailState, Handle:iQuery, szError[], iErrorCode)
 	{
 		case TQUERY_CONNECT_FAILED: 
 		{
-			log_to_file("mix_system.log", "[SQL Error] Connection failed (%i): %s", iErrorCode, szError);		}
+			log_to_file("mix_system_stats.log", "[SQL Error] Connection failed (%i): %s", iErrorCode, szError);		}
 		case TQUERY_QUERY_FAILED:
 		{
-			log_to_file("mix_system.log", "[SQL Error] Query failed (%i): %s", iErrorCode, szError);
+			log_to_file("mix_system_stats.log", "[SQL Error] Query failed (%i): %s", iErrorCode, szError);
 		}
 	}
 }


### PR DESCRIPTION
- MixSettings.ini additions:
     - Implemented `KNIFE_ROUND_START_DELAY ` to control voting time after knife round end. 
     - Implemented `DEFAULT_START_POINTS` setting to control new players start points.

- Implemented `regex` to replace unwanted text in player's name. Fixes #11
- Fixed player's score swap at halftime. Fixes #11 #7
- Fixed stats restore after reconnect ( now stored by `AuthID` instead of `Name` )
- Optimized `Knife Round` weapons event handle logic.
- Fixed `Rank` logic when showcasing in player's name.
- Implemented `SetGameDesc` method to set game description based on what is happening on server.
- Fixed problems with `client_print_color` 2nd parameter being incorrect.

- mix_system.txt: 
   - Added more entries related to `mix_system.sma`