### PR TITLE
Bugfixed `C4` dissapearence and new `Name` feature

### DIFF
--- a/configs/MixSettings.ini
+++ b/configs/MixSettings.ini
@@ -243,7 +243,7 @@ POINTS_SEMIACE = 3
 POINTS_TEAM_WIN = 5
 
 # Shows player's points in name or his rank based on points
-# 0 - Show the rank | 1 - Show the points
+# -1 - Don't show any indicator | 0 - Show the rank | 1 - Show the points
 POINTS_SHOW_NAME = 1
 
 # Rank letters shown to each player based on their points

--- a/scripting/mix_system.sma
+++ b/scripting/mix_system.sma
@@ -452,6 +452,7 @@ new g_iRet
 new Regex:g_rePattern
 
 new g_szConfigsDir[48]
+new g_iGaveC4
 
 public plugin_init()
 {
@@ -1556,6 +1557,9 @@ public RG_Player_Spawn_Post(id)
 		{
 			g_iPoints[id] = 0
 		}
+
+		if(g_ePointSystem[PointsShowName] < 0)
+			return
 
 		new aRank[Ranking]
 
@@ -3056,6 +3060,7 @@ public task_delayed_members()
 {
 	set_member_game(m_bCTCantBuy, false)
 	set_member_game(m_bTCantBuy, false)
+	g_iGaveC4 = false
 }
 
 public task_give_equipment(iPlayer)
@@ -3081,6 +3086,12 @@ public task_give_equipment(iPlayer)
 		case TEAM_TERRORIST:
 		{
 			get_cvar_string("mp_t_default_weapons_secondary", szDefaultWeap, charsmax(szDefaultWeap))
+			// if we stripped the C4 from player, give one to a random player
+			if(get_member_game(m_bMapHasBombZone) && !g_iGaveC4)
+			{
+				rg_give_item(iPlayer, "weapon_c4", GT_REPLACE)
+				g_iGaveC4 = true
+			}
 		}
 		case TEAM_CT:
 		{


### PR DESCRIPTION
- fixed a bug when C4 would dissapear when `terrorists` were stripped of the weapons at half-time swap

- added a new feature for `Points Show Name` during a match. Closes #19